### PR TITLE
Various Changes

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -29,3 +29,5 @@ dependencies {
     'rsg-core',
     'menu_base'
 }
+
+export 'CheckHorseBondingLevel'

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -20,6 +20,9 @@ Config.FeedSugarCubeStamina = 25 -- amount of stamina increase when you feed you
 -- horse xp settings
 Config.EnableReadUp = 1000 -- amount of XP you need to enable horse rear-up [Q] key
 
+-- horse bonding settings
+Config.MaxBondingLevel = 5000
+
 -- config blips
 Config.Blip = {
     blipName = 'Horse Stable', -- Config.Blip.blipName


### PR DESCRIPTION
- Add horse bonding mechanism based on horse EXP (configurable)

  **Default EXP Settings:**
  - 1250 = Level 1
  - 2500 = Level 2
  - 3750 = Level 3
  - 5000 = Level 4

- Add function export for 'Horse Bonding Level Checks' (useful for horse trainer jobs or just for anything)
- Remove horse rear up using 'Q' hotkey. From now on when the horse is fully bonded we can use standard/default RDR2 action for rear up, skid, drift, etc
- etc