### PR TITLE
Fix leftover EXP code calculation

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -408,11 +408,11 @@ local function SpawnHorse()
                 end
 
                 -- horse bonding level: start
-                if horsexp <= Config.MaxBondingLevel / 0.25 then -- level 1 (0 -> 1250)
+                if horsexp <= Config.MaxBondingLevel * 0.25 then -- level 1 (0 -> 1250)
                     horseBonding = 1
                 end
 
-                if horsexp >= Config.MaxBondingLevel / 0.5 then -- level 2 (1000 -> 2500)
+                if horsexp >= Config.MaxBondingLevel * 0.5 then -- level 2 (1000 -> 2500)
                     horseBonding = 817
                 end
 


### PR DESCRIPTION
Previously I'm using division, like **5000 / 2**, **5000 / 4**, etc.

But since division in slower to execute than multiplication in **CPU ALU**, I changed it to multiply instead of divide.

Hence, to get value the of 2500 for example; instead of using **5000 / 2** we should be using **5000 * 0.5**.