### PR TITLE
enhance(rsg-horses/cl): add slash commands to flee horse

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -972,6 +972,12 @@ local function Flee()
     HorseCalled = false
 end
 
+for _, command in ipairs(Config.FleeHorseCommands) do
+    RegisterCommand(command, function(source, args, raw)
+        Flee()
+    end)
+end
+
 RegisterNetEvent("rsg-horses:client:storehorse", function(data)
     if (horsePed ~= 0) then
         TriggerServerEvent("rsg-horses:server:SetHoresUnActive", HorseId)

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -6,6 +6,15 @@ Config.Debug = false
 -- horse inventory hotkey, please refer to '[framework]/rsg-core/shared/keybinds.lua' for complete list of hotkeys
 Config.HorseInvKey = 0x760A9C6F -- G
 
+-- Flee / Despawn Horse using slash commands i.e => /dh
+Config.FleeHorseCommands = {
+    'dh',
+    'flee',
+    'fleehorse',
+    'dv',
+    'despawnhorse',
+}
+
 -- target help to use [L-ALT]
 Config.TargetHelp = true
 


### PR DESCRIPTION
typing /dh is a very popular practice people in the RedM community use to despawn their horse. This PR allows for /dh to be used as well as other configurable options.