### PR TITLE
Fix of issue where setting horse default relation group with player to 1 (friendly) would make all horses in gameworld friendly aswell

### DIFF
--- a/client/horses.lua
+++ b/client/horses.lua
@@ -10,7 +10,7 @@ function SpawnHorses(horsemodel, horsecoords, heading)
     SetEntityInvincible(spawnedHorse, true)
     FreezeEntityPosition(spawnedHorse, true)
     SetBlockingOfNonTemporaryEvents(spawnedHorse, true)
-    SetPedCanBeTargetted(spawnedPed, false)
+    SetPedCanBeTargetted(spawnedHorse, false)
 
     if Config.FadeIn then
         for i = 0, 255, 51 do

--- a/client/horses.lua
+++ b/client/horses.lua
@@ -10,7 +10,6 @@ function SpawnHorses(horsemodel, horsecoords, heading)
     SetEntityInvincible(spawnedHorse, true)
     FreezeEntityPosition(spawnedHorse, true)
     SetBlockingOfNonTemporaryEvents(spawnedHorse, true)
-    -- set relationship group between horse and player
     SetPedCanBeTargetted(spawnedPed, false)
 
     if Config.FadeIn then

--- a/client/horses.lua
+++ b/client/horses.lua
@@ -11,8 +11,7 @@ function SpawnHorses(horsemodel, horsecoords, heading)
     FreezeEntityPosition(spawnedHorse, true)
     SetBlockingOfNonTemporaryEvents(spawnedHorse, true)
     -- set relationship group between horse and player
-    SetPedRelationshipGroupHash(spawnedHorse, GetPedRelationshipGroupHash(spawnedHorse))
-    SetRelationshipBetweenGroups(1, GetPedRelationshipGroupHash(spawnedHorse), `PLAYER`)
+    SetPedCanBeTargetted(spawnedPed, false)
 
     if Config.FadeIn then
         for i = 0, 255, 51 do

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aw
 game 'rdr3'
 
 description 'rsg-horses'
-version '2.0.3'
+version '2.0.4'
 
 shared_scripts {
     '@ox_lib/init.lua',


### PR DESCRIPTION
Steps to reproduce the issue:
1) walk near stable with display horses
2) observe behavior of wild horses

Instead of setting horse group friendly to player (assuming to prevent player from punching it), we can disable targeting of horse ped and not change default horse group relation with player, which has unintended side effects